### PR TITLE
fix: unscrollable landscape

### DIFF
--- a/app/src/main/res/layout-land/fragment_home.xml
+++ b/app/src/main/res/layout-land/fragment_home.xml
@@ -184,17 +184,15 @@
         </LinearLayout>
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/category_items_recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/category_holder"
-            tools:itemCount="11"
-            tools:listitem="@layout/full_item_viewholder" />
+                android:id="@+id/category_items_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/category_holder"
+                tools:itemCount="11"
+                tools:listitem="@layout/full_item_viewholder" />
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/guideline"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Was unable to check the code since, but just checked it now and I found out that recycler view was constrained to the bottom and top, thereby giving it a value of 0dp because the amount of space left to take in the bottom recycler view is non existent